### PR TITLE
Comment out CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-stephencharlesweiss.com
+# stephencharlesweiss.com


### PR DESCRIPTION
Right now the CNAME is routing to a site hosted elsewhere, defeating the purpose.